### PR TITLE
add-data-and-scripts-to-gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 **/node_modules/
 **/bower_components/
 **/npm-debug.log
+4-data/
+3-scripts/
 _r&d/
 .idea/
 .DS_Store


### PR DESCRIPTION
Added `3-scripts` and `4-data` to .gitignore because they will always be changing locally on our machines and there is really no reason to persist them
